### PR TITLE
Fixed SPI protocol error

### DIFF
--- a/spi_hardware_test.py
+++ b/spi_hardware_test.py
@@ -19,7 +19,7 @@ def buildReadCommand(channel):
     startBit = 0x01
     singleEnded = 0x08
     
-    return [startBit, singleEnded|(channel<<4), 0]
+    return [startBit, (singleEnded|channel)<<4, 0]
     
 def processAdcValue(result):
     '''Take in result as array of three bytes. 


### PR DESCRIPTION
SPI protocol specifies to send first single/diff use bit and then channel number. Previous code resulted in malformation of second byte (0 followed by 3-bit channel followed by single/diff bit followed by three 0).

Issue fixed.